### PR TITLE
Remove the timings section from the intro 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,6 @@
 # Introduction to Software Architecture Design
 
-### Schedule
-- Set Up and Learning Outcomes \ Individually \ 5 mins
-- Group Introduction to Topic \ 5 mins
-- Read "What Is Software Architecture Design?" \ Individually \ 5 mins   
-- Discuss ^ all together \ 5 mins
-- Exercise 1 \ All together \ 5 mins
-- Read "Why Is Architecture Important?" \ Individually \ 5 mins
-- Discuss ^ all together \ 5 mins
-- Read Types of Software architecture \ 5 mins
-- Go through Key Principles \ As a group \ 5 mins
-- Exercise 2 \ Pairs \ Restructure a file system \ 10 mins
-- Exercise 3 \ Individually \ 25 mins
-- Wrap up and present ideas \ 20 mins
-
-Total: < 2 hours
+### Getting Started
 
 Clone this repo: `git clone https://github.com/lucyrose93/Workshop-Software-Architecture-Design.git`
 


### PR DESCRIPTION
The timings section does not accurately reflect the pace at which we have been working today. This workshop should now be time-boxed for 1 hour (see #452 in master ref), to make room for the afternoon workshop on Software Design, which we have now decided to deliver in full (see #300 in master ref). 